### PR TITLE
Added CSV Output + Minor Changes

### DIFF
--- a/laps.py
+++ b/laps.py
@@ -2,7 +2,6 @@
 from ldap3 import ALL, Server, Connection, NTLM, extend, SUBTREE
 import argparse
 from datetime import datetime
-from datetime import date
 parser = argparse.ArgumentParser(description='Dump LAPS Passwords')
 parser.add_argument('-u','--username',  help='username for LDAP', required=True)
 parser.add_argument('-p','--password',  help='password for LDAP (or LM:NT hash)',required=True)
@@ -45,7 +44,7 @@ def main():
             print (str(entry['cn']) +" "+ str(entry['ms-Mcs-AdmPwd']))
             if args.output != None:
                 epoch = (int(str(entry['ms-Mcs-AdmPwdExpirationTime']))/10000000) - 11644473600
-                convertedTime = date.fromtimestamp(epoch).strftime("%m-%d-%Y")
+                convertedTime = datetime.fromtimestamp(epoch).strftime("%m-%d-%Y")
                 f = open(filename,'a')
                 f.writelines(str(entry['cn'])+",\""+ str(entry['ms-Mcs-AdmPwd']) + "\"," + convertedTime + "," + str(epoch) + "," + runtime +"\n")
                 f.close()

--- a/laps.py
+++ b/laps.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 from ldap3 import ALL, Server, Connection, NTLM, extend, SUBTREE
 import argparse
-
+from datetime import datetime
+from datetime import date
 parser = argparse.ArgumentParser(description='Dump LAPS Passwords')
 parser.add_argument('-u','--username',  help='username for LDAP', required=True)
 parser.add_argument('-p','--password',  help='password for LDAP (or LM:NT hash)',required=True)
 parser.add_argument('-l','--ldapserver', help='LDAP server (or domain)', required=False)
 parser.add_argument('-d','--domain', help='Domain', required=True)
+parser.add_argument('-o','--output', help='Output file to CSV', required=False)
+
 
 def base_creator(domain):
     search_base = ""
@@ -17,22 +20,40 @@ def base_creator(domain):
 
 
 def main():
+    # Get the current runtime for logging purposes
+    getTime = datetime.now()
+    runtime = getTime.strftime("%m-%d-%Y %H:%M:%S") 
+    print("LAPS Dumper - Running at " + runtime)
+    
     args = parser.parse_args()
+    #Check if the user specifies a file output. Note: Args.output literally sets itself to "None".
+    if args.output != None:
+        filename = args.output + getTime.strftime("-%m-%d-%Y.csv")
+        f = open(filename,'w')
+        header = ['Computer,Password,Expiration Time,Epoch Expiration Time,Query Time\n']
+        f.writelines(header)
+        f.close()
+
     if args.ldapserver:
         s = Server(args.ldapserver, get_info=ALL)
     else:
         s = Server(args.domain, get_info=ALL)
     c = Connection(s, user=args.domain + "\\" + args.username, password=args.password, authentication=NTLM, auto_bind=True)
     try:
-    	c.search(search_base=base_creator(args.domain), search_filter='(&(objectCategory=computer)(ms-MCS-AdmPwd=*))',attributes=['ms-MCS-AdmPwd','SAMAccountname'])
+    	c.search(search_base=base_creator(args.domain), search_filter='(&(objectCategory=computer)(ms-MCS-AdmPwd=*))',attributes=['ms-MCS-AdmPwd','ms-Mcs-AdmPwdExpirationTime','cn'])
     	for entry in c.entries:
-        	print (str(entry['sAMAccountName']) +":"+ str(entry['ms-Mcs-AdmPwd']))
+            print (str(entry['cn']) +" "+ str(entry['ms-Mcs-AdmPwd']))
+            if args.output != None:
+                epoch = (int(str(entry['ms-Mcs-AdmPwdExpirationTime']))/10000000) - 11644473600
+                convertedTime = date.fromtimestamp(epoch).strftime("%m-%d-%Y")
+                f = open(filename,'a')
+                f.writelines(str(entry['cn'])+",\""+ str(entry['ms-Mcs-AdmPwd']) + "\"," + convertedTime + "," + str(epoch) + "," + runtime +"\n")
+                f.close()
     except Exception as ex:
     	if ex.args[0] == "invalid attribute type ms-MCS-AdmPwd":
     		print("This domain does not have LAPS configured")
     	else:
     		print(ex)
-
     	
 if __name__ == "__main__":
     main()

--- a/laps.py
+++ b/laps.py
@@ -25,7 +25,7 @@ def main():
     print("LAPS Dumper - Running at " + runtime)
     
     args = parser.parse_args()
-    #Check if the user specifies a file output. Note: Args.output literally sets itself to "None".
+    #Check if the user specifies a file output. If so, it creates a new CSV.
     if args.output != None:
         filename = args.output + getTime.strftime("-%m-%d-%Y.csv")
         f = open(filename,'w')
@@ -42,6 +42,7 @@ def main():
     	c.search(search_base=base_creator(args.domain), search_filter='(&(objectCategory=computer)(ms-MCS-AdmPwd=*))',attributes=['ms-MCS-AdmPwd','ms-Mcs-AdmPwdExpirationTime','cn'])
     	for entry in c.entries:
             print (str(entry['cn']) +" "+ str(entry['ms-Mcs-AdmPwd']))
+            #Appends the Machine Name (not Machine Account) + Password + Password Expiration + Epoch (for some reason it wouldn't convert HMS correctly, so I opted for perserving the epoch in logs) + Runtime to the csv.
             if args.output != None:
                 epoch = (int(str(entry['ms-Mcs-AdmPwdExpirationTime']))/10000000) - 11644473600
                 convertedTime = datetime.fromtimestamp(epoch).strftime("%m-%d-%Y")


### PR DESCRIPTION
Hi there,
I made a PR based on this issue (https://github.com/n00py/LAPSDumper/issues/4). The script now has an option to log Computer + Password + Expiration Date (m/d/y)+ Epoch of the expiration date (for the most accurate results), and the runtime of the script to a CSV file.

Also, I altered the print statement from
EXAMPLEPC$:Password
to
EXAMPLEPC Password

For people who have not worked with LAPS before (or even those who have), it can seem like the program retrieved the machine account password (which isn't the case), so I altered it to display the canonical name instead of the samAccountName, since the samAccountName only stores the machine account name. Someone could also modify the script to contain the DNS Host Name for the least amount of confusion... I'll be working on searching SysVol for LAPS configurations so it can display the specific account name that it needs to rotate the password for. Anyways, I'm babbling on.

Here's some pictures:
![image](https://user-images.githubusercontent.com/44957111/175144799-d47bf295-c7bf-4f84-86b7-b9eda288c05d.png)

![image](https://user-images.githubusercontent.com/44957111/175144903-c26ab268-61bb-482d-aba1-0d26779ffc28.png)

Nice work :)